### PR TITLE
Fix broken "Top Commands" and "Top Keys" when not using DB0

### DIFF
--- a/src/redis-monitor.py
+++ b/src/redis-monitor.py
@@ -77,8 +77,12 @@ class MonitorThread(threading.Thread):
 				epoch = float(t)
 				timestamp = datetime.datetime.fromtimestamp(epoch)
 
-				command = parts[1].replace('"','').upper()
+				# Strips '(db N)' out of the monitor str to avoid breaking
+				if parts[1]=="(db":
+					parts = [parts[0]] + parts[3:]
 
+				command = parts[1].replace('"','').upper()
+					
 				if len(parts)>2:					
 					keyname = parts[2].replace('"','').strip()
 				else:


### PR DESCRIPTION
The reports for "Top Commands" and "Top Keys" break when you try monitoring a redis instance running on a different database than 0. (i.e. if you run SELECT 10 to use db 10).

This patch simply throws away the DB info so as to not break the remaining code.
