### PR TITLE
Support format change in 2.6

### DIFF
--- a/src/redis-monitor.py
+++ b/src/redis-monitor.py
@@ -202,7 +202,8 @@ class RedisMonitor(object):
 			
 
 	def Stop(self):
-		print "shutting down..."
+		if args.quiet==False:
+			print "shutting down..."
 		for t in self.threads:
 				t.stop()
 		self.active = False
@@ -222,6 +223,7 @@ class RedisMonitor(object):
 if __name__ == '__main__':
 	parser = argparse.ArgumentParser(description='Monitor redis.')
 	parser.add_argument('--duration', type = int, help = "duration to run the monitor command (in seconds)", required = True) 
+	parser.add_argument('--quiet', help = "do  not write anything to standard output", required = False, action='store_true') 
 	args = parser.parse_args()
 	duration = args.duration
 	monitor = RedisMonitor()


### PR DESCRIPTION
Accommodate the format change of the output from MONITOR in Redis 2.6 by stripping [N n.n.n.n:nn] from the string
