### PR TITLE
add support for passing logging options to redis-live.py

### DIFF
--- a/src/redis-live.py
+++ b/src/redis-live.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import tornado.ioloop
+import tornado.options
 import tornado.web
 
 from api.controller.BaseStaticFileHandler import BaseStaticFileHandler
@@ -26,5 +27,6 @@ application = tornado.web.Application([
 
 
 if __name__ == "__main__":
+	tornado.options.parse_command_line()
 	application.listen(8888)
 	tornado.ioloop.IOLoop.instance().start()


### PR DESCRIPTION
- example usage
  $ ./redis-live.py --logging=debug

That's one small step for codebase, one giant leap for developers :-)
