### PR TITLE
Added a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+argparse==1.2.1
+python-dateutil==1.5
+redis
+tornado==2.1.1


### PR DESCRIPTION
Note that the redis version is not specified, so it is possible to setup a virtualenv with whatever redis version you see fit.

This also sets the stage for a proper PyPI package, as per #31 ;)
