### PR TITLE
"save_monitor_command" store DailyKeyCount error

### DIFF
--- a/src/dataprovider/redisprovider.py
+++ b/src/dataprovider/redisprovider.py
@@ -76,7 +76,7 @@ class RedisStatsProvider(object):
         pipeline.zincrby(key_count_key, keyname, 1)
 
         key_count_key = server + ":DailyKeyCount:" + current_date
-        pipeline.zincrby(key_count_key, command, 1)
+        pipeline.zincrby(key_count_key, keyname, 1)
 
         # keep aggregate command in a hash
         command_count_key = server + ":CommandCountBySecond"


### PR DESCRIPTION
def save_monitor_command() 
line 79 pipeline.zincrby(key_count_key, command, 1)

should be "pipeline.zincrby(key_count_key, keyname, 1)"
