### PR TITLE
Fix #63 for python 2.6 support on datetime.total_seconds method

### DIFF
--- a/src/api/util/timeutils.py
+++ b/src/api/util/timeutils.py
@@ -2,5 +2,15 @@ from datetime import datetime
 
 def convert_to_epoch(timestamp):
 	diff = (timestamp - datetime(1970, 1, 1))
-	seconds = int(diff.total_seconds())
+	seconds = int(total_seconds(diff))
 	return seconds
+
+
+# Original fix for Py2.6: https://github.com/mozilla/mozdownload/issues/73
+def total_seconds(dt):
+	# Keep backward compatibility with Python 2.6 which doesn't have
+	# this method
+	if hasattr(datetime, 'total_seconds'):
+		return dt.total_seconds()
+	else:
+		return (dt.microseconds + (dt.seconds + dt.days * 24 * 3600) * 10**6) / 10**6


### PR DESCRIPTION
I quickly found a fix to this bug in the Mozilla github :https://github.com/mozilla/mozdownload/issues/73

Fix for issue #63 
