### PR TITLE
Remove incorrect version of total_seconds()

### DIFF
--- a/src/api/util/timeutils.py
+++ b/src/api/util/timeutils.py
@@ -1,4 +1,5 @@
 import datetime
+# Original fix for Py2.6: https://github.com/mozilla/mozdownload/issues/73
 def total_seconds(td):
     # Keep backward compatibility with Python 2.6 which doesn't have
     # this method
@@ -14,13 +15,3 @@ def convert_to_epoch(timestamp):
 	diff = (timestamp - datetime.datetime(1970, 1, 1))
 	seconds = int(total_seconds(diff))
 	return seconds
-
-
-# Original fix for Py2.6: https://github.com/mozilla/mozdownload/issues/73
-def total_seconds(dt):
-	# Keep backward compatibility with Python 2.6 which doesn't have
-	# this method
-	if hasattr(datetime.datetime, 'total_seconds'):
-		return dt.total_seconds()
-	else:
-		return (dt.microseconds + (dt.seconds + dt.days * 24 * 3600) * 10**6) / 10**6


### PR DESCRIPTION
The second copy of total_seconds() is incorrect as it looks for
the total_seconds method in datetime.datetime, not datetime.timedelta.

convert_to_epoch() still worked since it would use the first version,
but any other user of total_seconds would get the second, incorrect
version which always takes the else branch.

This commit simply removes the incorrect version.
