### PR TITLE
Set default_filename to index.html

### DIFF
--- a/src/redis-live.py
+++ b/src/redis-live.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     (r"/api/commands", CommandsController),
     (r"/api/topcommands", TopCommandsController),
     (r"/api/topkeys", TopKeysController),
-    (r"/(.*)", BaseStaticFileHandler, {"path": "www"})
+    (r"/(.*)", BaseStaticFileHandler, {"path": "www", "default_filename": "index.html"})
     ]
 
     server_settings = {'debug': options.debug}


### PR DESCRIPTION
To serve index.html automatically when a directory is requested, add
default_filename as an initializer argument for StaticFileHandler.