### PR TITLE
[solved] "while self.active" use 100%

### DIFF
--- a/src/redis-monitor.py
+++ b/src/redis-monitor.py
@@ -266,7 +266,7 @@ class RedisMonitor(object):
 
         try:
             while self.active:
-                pass
+                time.sleep(1)
         except (KeyboardInterrupt, SystemExit):
             self.stop()
             t.cancel()


### PR DESCRIPTION
when i  execute redis-monitor.py to collect redis info, while loop will use 100% of available idle CPU resources.
time.sleep(xx) for seconds can resolve the problem.